### PR TITLE
Unpin scipy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ tqdm
 tensorboard
 descript-audiotools>=0.7.2
 descript-audio-codec
-scipy==1.10.1
+scipy
 accelerate>=0.26.0


### PR DESCRIPTION
Latest pip version fails with SciPy 1.10.1, unpining to avoid compatibiliy issues.