### PR TITLE
feat: Use SDPA as default attention for broader compatibility

### DIFF
--- a/inference/infer.py
+++ b/inference/infer.py
@@ -84,7 +84,7 @@ mmtokenizer = _MMSentencePieceTokenizer("./mm_tokenizer_v0.2_hf/tokenizer.model"
 model = AutoModelForCausalLM.from_pretrained(
     stage1_model, 
     torch_dtype=torch.bfloat16,
-    attn_implementation="flash_attention_2", # To enable flashattn, you have to install flash-attn
+    attn_implementation="sdpa",  # Use SDPA instead of flash_attention_2
     # device_map="auto",
     )
 # to device, if gpu is available
@@ -262,7 +262,7 @@ print("Stage 2 inference...")
 model_stage2 = AutoModelForCausalLM.from_pretrained(
     stage2_model, 
     torch_dtype=torch.bfloat16,
-    attn_implementation="flash_attention_2",
+    attn_implementation="sdpa",  # Use SDPA instead of flash_attention_2
     # device_map="auto",
     )
 model_stage2.to(device)


### PR DESCRIPTION
## Summary
- Replace `flash_attention_2` with `sdpa` (Scaled Dot Product Attention) as the default attention implementation in `inference/infer.py`
- Improves compatibility across different environments without sacrificing performance

## Motivation
The current default requires `flash-attn` to be installed, which:
- Has complex build requirements (CUDA, specific compilers)
- Doesn't support Python 3.14+ yet
- Fails with cryptic errors when not installed

SDPA (Scaled Dot Product Attention) is:
- Native to PyTorch (no extra dependencies)
- Compatible with Python 3.14+
- Still highly optimized (uses cuDNN/Flash under the hood when available)

## Changes
- Changed `attn_implementation="flash_attention_2"` to `attn_implementation="sdpa"` in both stage1 and stage2 model loading

## Testing
Tested inference successfully with:
- Python 3.14
- PyTorch 2.7
- transformers 5.0

Users who prefer flash_attention_2 can still modify this locally for potentially better performance on supported systems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)