### PR TITLE
docs: add hf download fallback + LFS-stub warning for xcodec_mini_infer (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ git clone https://github.com/multimodal-art-projection/YuE.git
 
 cd YuE/inference/
 git clone https://huggingface.co/m-a-p/xcodec_mini_infer
+
+# If `git clone` produced tiny ~133-byte files instead of the real checkpoints,
+# git-lfs was not initialized or the Hugging Face LFS bandwidth quota is exceeded
+# (see issue #118). In that case, download via the Hugging Face CLI instead:
+#   pip install -U huggingface_hub
+#   hf download m-a-p/xcodec_mini_infer --local-dir xcodec_mini_infer
 ```
 
 ### 3. Run the inference


### PR DESCRIPTION
**Add a Hugging Face CLI download fallback + an LFS-stub warning to the model-download step (#118).**

Setup step 2 tells users to `git clone https://huggingface.co/m-a-p/xcodec_mini_infer`.
When git-lfs isn't initialized — or when the Hugging Face **LFS bandwidth quota is
exceeded (#118)** — that clone silently produces tiny ~133-byte LFS *pointer* files
instead of the real checkpoints, and inference then fails confusingly downstream.

## Change
- **`README.md`** (step 2) — keep the existing `git clone` path, and add a short note
  that if the clone yields ~133-byte stub files, download via the Hugging Face CLI
  instead:
  ```bash
  pip install -U huggingface_hub
  hf download m-a-p/xcodec_mini_infer --local-dir xcodec_mini_infer
  ```
  Referencing #118.

Docs-only; no code change.

---
*Disclosure: drafted with AI assistance (Claude); reviewed and submitted by me. The commit carries a `Co-Authored-By` trailer.*
