### PR TITLE
Merge reviewed YuE v1 compatibility and download fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ git clone https://github.com/multimodal-art-projection/YuE.git
 
 cd YuE/inference/
 git clone https://huggingface.co/m-a-p/xcodec_mini_infer
+
+# If `git clone` produced tiny ~133-byte files instead of the real checkpoints,
+# git-lfs was not initialized or the Hugging Face LFS bandwidth quota is exceeded
+# (see issue #118). In that case, download via the Hugging Face CLI instead:
+#   pip install -U huggingface_hub
+#   hf download m-a-p/xcodec_mini_infer --local-dir xcodec_mini_infer
 ```
 
 ### 3. Run the inference

--- a/README.md
+++ b/README.md
@@ -87,19 +87,18 @@ To use a **GUI/Gradio** interface, check out:
 - [YuE-Interface](https://github.com/alisson-anjos/YuE-Interface)  
 
 ### 1. Install environment and dependencies
-Make sure properly install flash attention 2 to reduce VRAM usage. 
+YuE v1 uses PyTorch scaled dot-product attention (SDPA) by default. A separate `flash-attn` installation is optional.
 ```bash
 # We recommend using conda to create a new environment.
 conda create -n yue python=3.8 # Python >=3.8 is recommended.
 conda activate yue
 # install cuda >= 11.8
 conda install pytorch torchvision torchaudio cudatoolkit=11.8 -c pytorch -c nvidia
-pip install -r <(curl -sSL https://raw.githubusercontent.com/multimodal-art-projection/YuE/main/requirements.txt)
+pip install -r <(curl -sSL https://raw.githubusercontent.com/multimodal-art-projection/YuE/YuE-v1/requirements.txt)
 
-# For saving GPU memory, FlashAttention 2 is mandatory. 
-# Without it, long audio may lead to out-of-memory (OOM) errors.
-# Be careful about matching the cuda version and flash-attn version
-pip install flash-attn --no-build-isolation
+# Optional: to use attn_implementation="flash_attention_2" instead of SDPA,
+# install a flash-attn version compatible with your PyTorch and CUDA versions:
+# pip install flash-attn --no-build-isolation
 ```
 
 ### 2. Download the infer code and tokenizer
@@ -109,15 +108,14 @@ pip install flash-attn --no-build-isolation
 sudo apt update
 sudo apt install git-lfs
 git lfs install
-git clone https://github.com/multimodal-art-projection/YuE.git
+git clone --branch YuE-v1 https://github.com/multimodal-art-projection/YuE.git
 
 cd YuE/inference/
 git clone https://huggingface.co/m-a-p/xcodec_mini_infer
 
-# If `git clone` produced tiny ~133-byte files instead of the real checkpoints,
-# git-lfs was not initialized or the Hugging Face LFS bandwidth quota is exceeded
-# (see issue #118). In that case, download via the Hugging Face CLI instead:
-#   pip install -U huggingface_hub
+# If the clone left Git LFS pointer files instead of real checkpoints,
+# download the tokenizer through the Hugging Face CLI:
+#   python -m pip install "huggingface_hub>=0.34,<1"
 #   hf download m-a-p/xcodec_mini_infer --local-dir xcodec_mini_infer
 ```
 

--- a/inference/infer.py
+++ b/inference/infer.py
@@ -84,7 +84,7 @@ mmtokenizer = _MMSentencePieceTokenizer("./mm_tokenizer_v0.2_hf/tokenizer.model"
 model = AutoModelForCausalLM.from_pretrained(
     stage1_model, 
     torch_dtype=torch.bfloat16,
-    attn_implementation="flash_attention_2", # To enable flashattn, you have to install flash-attn
+    attn_implementation="sdpa",  # Use SDPA instead of flash_attention_2
     # device_map="auto",
     )
 # to device, if gpu is available
@@ -262,7 +262,7 @@ print("Stage 2 inference...")
 model_stage2 = AutoModelForCausalLM.from_pretrained(
     stage2_model, 
     torch_dtype=torch.bfloat16,
-    attn_implementation="flash_attention_2",
+    attn_implementation="sdpa",  # Use SDPA instead of flash_attention_2
     # device_map="auto",
     )
 model_stage2.to(device)


### PR DESCRIPTION
Integrate the SDPA default from #149 and the checkpoint download fallback from #153 into YuE-v1, preserving both contributor commits.

Update the v1 setup instructions to clone YuE-v1 and load its requirements, make external flash-attn optional, and keep the fallback Hub version compatible with Transformers 4. Remove the unsupported diagnosis that #118 describes a Hugging Face quota error.

Validation: CPU smoke tests for Llama GQA/MHA loading, cached decoding, BF16 generation with classifier-free guidance, and batched seven-token generation; Python syntax and README command checks. No full-weight song generation or GPU performance claim. PR #138 is excluded because it blocks the end-of-audio token and a valid residual-code token.