### PR TITLE
Fix flash attention check and fallback

### DIFF
--- a/src/yue2/cuda_graph.py
+++ b/src/yue2/cuda_graph.py
@@ -11,6 +11,18 @@ import torch
 import torch.nn.functional as F
 
 
+def _flash_attention_available(model):
+    """Check the op is compiled in: Windows wheels register it as a stub that raises."""
+    config = model.config
+    q = torch.zeros(1, config.num_attention_heads, 1, config.head_dim,
+                    device=model.device, dtype=model.dtype)
+    kv = torch.zeros(1, config.num_key_value_heads, 1, config.head_dim,
+                     device=model.device, dtype=model.dtype)
+    params = torch._C._SDPAParams(q, kv, kv, None, 0.0, False,
+                                  config.num_attention_heads != config.num_key_value_heads)
+    return torch.backends.cuda.can_use_flash_attention(params)
+
+
 class _PrefixCache:
     """A single branch view used only by the original eager HF prefill."""
     def __init__(self, keys, values, branch):
@@ -77,6 +89,8 @@ class GraphAR:
         # Torch 2.10 is pinned by the package. Its native variable-length FA
         # accepts GPU effective lengths; the public masked SDPA can select a
         # much slower math kernel. Keep a cuDNN/public-SDPA fallback explicit.
+        if flash:
+            flash = _flash_attention_available(model)
         if attention_backend == "auto":
             attention_backend = "flash" if flash else "cudnn" if fused and torch.backends.cudnn.is_available() else "sdpa"
         if attention_backend == "flash" and not flash:

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from yue2.cuda_graph import GraphAR
+from yue2.cuda_graph import GraphAR, _flash_attention_available
 from yue2.modeling_yue2 import StaticKVCache, YuE2Config, YuE2ForCausalLM
 
 
@@ -115,6 +115,17 @@ def test_quantized_model_requires_explicit_eager_path(model):
         GraphAR(model, [[1]], 2, capture=False)
 
 
+def test_explicit_flash_backend_is_rejected_without_a_cuda_model(model):
+    with pytest.raises(ValueError, match="unavailable"):
+        GraphAR(model, [[1]], 2, capture=False, attention_backend="flash")
+
+
+def test_flash_availability_consults_the_sdpa_metadata_check(model):
+    assert _flash_attention_available(model) is False
+    with patch.object(torch.backends.cuda, "can_use_flash_attention", return_value=True):
+        assert _flash_attention_available(model) is True
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA capture requires an actual allocated GPU")
 @pytest.mark.parametrize("prefixes", [[[2, 3, 4]], [[2, 3, 4, 5], [6]]])
 @pytest.mark.parametrize("backend", ["auto", "cudnn"])
@@ -131,7 +142,11 @@ def test_real_cuda_graph_bfloat16_parity(model, prefixes, backend, fused):
         graph = GraphAR(model, prefixes, 5, attention_backend=backend, fuse_projections=fused)
         torch.testing.assert_close(graph.prefill(), expected, atol=0, rtol=0)
         assert graph.graph is not None
-        assert graph.attention_backend == ("flash" if backend == "auto" else "cudnn")
+        if backend == "auto":
+            expected_backend = "flash" if _flash_attention_available(model) else "cudnn"
+        else:
+            expected_backend = backend
+        assert graph.attention_backend == expected_backend
         for keys, values in zip(graph.keys, graph.values):
             for branch, prefix in enumerate(prefixes):
                 keys[branch, len(prefix)+1:].fill_(1000)


### PR DESCRIPTION
The existing check for flash attention availability uses `hasattr`:

https://github.com/multimodal-art-projection/YuE/blob/92a73cc7652fcc1f937855e4b765e0a0edd7ff2e/src/yue2/cuda_graph.py#L75-L76

But this doesn't properly catch cases where torch isn't built with flash attention (i.e. the official prebuilt Windows wheels for torch 2.10.0), because the op is still registered, but just a stub that raises. This causes inference on Windows using the official torch 2.10.0 wheels to fail with:

```
Traceback (most recent call last):
  File "C:\ML\YuE\test.py", line 15, in <module>
    song = pipe(style=style, lyrics=lyrics, cot="full", seed=demo["seed"])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\pipeline.py", line 384, in __call__
    plan = self.plan(request=request, abc_sampling=abc_sampling, cancelled=cancelled, on_token=on_token)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\pipeline.py", line 266, in plan
    ids, timing, truncated = self._generate(token_prefixes(request, self.tokenizer), sampling,
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\pipeline.py", line 249, in _generate
    result = generate_tokens(model, prefix, sampling, seed, phase,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\torch\utils\_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\sampling.py", line 93, in generate_tokens
    logits = graph.prefill()
             ^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\torch\utils\_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\cuda_graph.py", line 203, in prefill
    self._capture()
  File "C:\ML\YuE\.venv\Lib\site-packages\torch\utils\_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\cuda_graph.py", line 180, in _capture
    self._decode()
  File "C:\ML\YuE\.venv\Lib\site-packages\torch\utils\_contextlib.py", line 124, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\yue2\cuda_graph.py", line 145, in _decode
    h = torch.ops.aten._flash_attention_forward(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ML\YuE\.venv\Lib\site-packages\torch\_ops.py", line 1209, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: USE_FLASH_ATTENTION was not enabled for build.
```

Here we instead use `torch.backends.cuda.can_use_flash_attention` to check whether flash attention is available, and then fall back to cuDNN of SDPA as needed.