### PR TITLE
Fix GraphAR backend selection on ROCm

### DIFF
--- a/src/yue2/cuda_graph.py
+++ b/src/yue2/cuda_graph.py
@@ -11,6 +11,21 @@ import torch
 import torch.nn.functional as F
 
 
+def _private_flash_attention_available(config, fused):
+    """Return whether YuE2's private packed FlashAttention route is usable."""
+    # ROCm exposes CUDA-shaped private operators, but its implementation does
+    # not support the ``seqused_k`` packed/varlen contract used by ``_decode``.
+    if torch.version.hip is not None:
+        return False
+    return fused and config.head_dim <= 256 and hasattr(torch.ops.aten, "_flash_attention_forward") and (
+        "seqused_k" in str(torch.ops.aten._flash_attention_forward.default._schema))
+
+
+def _cudnn_attention_available(fused):
+    """Return whether the NVIDIA-only cuDNN attention backend is usable."""
+    return torch.version.hip is None and fused and torch.backends.cudnn.is_available()
+
+
 class _PrefixCache:
     """A single branch view used only by the original eager HF prefill."""
     def __init__(self, keys, values, branch):
@@ -72,16 +87,16 @@ class GraphAR:
         if attention_backend not in {"auto", "flash", "cudnn", "sdpa"}:
             raise ValueError("attention_backend must be auto, flash, cudnn, or sdpa")
         fused = self.device.type == "cuda" and self.dtype in {torch.bfloat16, torch.float16} and config.head_dim % 8 == 0
-        flash = fused and config.head_dim <= 256 and hasattr(torch.ops.aten, "_flash_attention_forward") and (
-            "seqused_k" in str(torch.ops.aten._flash_attention_forward.default._schema))
+        flash = _private_flash_attention_available(config, fused)
+        cudnn = _cudnn_attention_available(fused)
         # Torch 2.10 is pinned by the package. Its native variable-length FA
         # accepts GPU effective lengths; the public masked SDPA can select a
         # much slower math kernel. Keep a cuDNN/public-SDPA fallback explicit.
         if attention_backend == "auto":
-            attention_backend = "flash" if flash else "cudnn" if fused and torch.backends.cudnn.is_available() else "sdpa"
+            attention_backend = "flash" if flash else "cudnn" if cudnn else "sdpa"
         if attention_backend == "flash" and not flash:
             raise ValueError("Pinned PyTorch variable-length CUDA FlashAttention is unavailable")
-        if attention_backend == "cudnn" and not (fused and torch.backends.cudnn.is_available()):
+        if attention_backend == "cudnn" and not cudnn:
             raise ValueError("cuDNN attention requires a supported CUDA dtype/head dimension")
         self.attention_backend = attention_backend
         self.ready, self.closed, self.steps = False, False, 0

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 import pytest
 import torch
 
-from yue2.cuda_graph import GraphAR
+from yue2.cuda_graph import GraphAR, _cudnn_attention_available, _private_flash_attention_available
 from yue2.modeling_yue2 import StaticKVCache, YuE2Config, YuE2ForCausalLM
 
 
@@ -115,11 +115,25 @@ def test_quantized_model_requires_explicit_eager_path(model):
         GraphAR(model, [[1]], 2, capture=False)
 
 
+def test_private_flash_attention_rejects_hip_before_operator_detection(model):
+    with patch.object(torch.version, "hip", "test-hip"):
+        assert _private_flash_attention_available(model.config, fused=True) is False
+
+
+def test_cudnn_attention_rejects_hip_before_backend_detection():
+    with patch.object(torch.version, "hip", "test-hip"), \
+            patch.object(torch.backends.cudnn, "is_available", return_value=True) as available:
+        assert _cudnn_attention_available(fused=True) is False
+        available.assert_not_called()
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA capture requires an actual allocated GPU")
 @pytest.mark.parametrize("prefixes", [[[2, 3, 4]], [[2, 3, 4, 5], [6]]])
-@pytest.mark.parametrize("backend", ["auto", "cudnn"])
+@pytest.mark.parametrize("backend", ["auto", "cudnn", "sdpa"])
 @pytest.mark.parametrize("fused", [False, True])
 def test_real_cuda_graph_bfloat16_parity(model, prefixes, backend, fused):
+    if torch.version.hip and backend == "cudnn":
+        pytest.skip("cuDNN attention is NVIDIA-specific; ROCm uses public SDPA")
     # Head size 8 exercises fused CUDA paths, as does the real head size 128.
     with torch.random.fork_rng(devices=[]):
         torch.manual_seed(146)
@@ -131,7 +145,13 @@ def test_real_cuda_graph_bfloat16_parity(model, prefixes, backend, fused):
         graph = GraphAR(model, prefixes, 5, attention_backend=backend, fuse_projections=fused)
         torch.testing.assert_close(graph.prefill(), expected, atol=0, rtol=0)
         assert graph.graph is not None
-        assert graph.attention_backend == ("flash" if backend == "auto" else "cudnn")
+        if backend == "auto":
+            expected_backend = "flash" if _private_flash_attention_available(model.config, fused=True) else (
+                "cudnn" if _cudnn_attention_available(fused=True) else "sdpa"
+            )
+        else:
+            expected_backend = backend
+        assert graph.attention_backend == expected_backend
         for keys, values in zip(graph.keys, graph.values):
             for branch, prefix in enumerate(prefixes):
                 keys[branch, len(prefix)+1:].fill_(1000)


### PR DESCRIPTION
Part of #167.

## Summary

This prevents GraphAR from selecting YuE2's private packed FlashAttention route or cuDNN when PyTorch is running on HIP. Public masked SDPA remains the fallback.

## Why

ROCm exposes parts of PyTorch through a CUDA-shaped API, but that does not make NVIDIA-specific kernels compatible. In the tested HIP environment, the packed FlashAttention path fails because `seqused_k` is unsupported, while cuDNN is not available at all.

The change is limited to backend selection and tests. It does not include MIOpen tuning or change the behavior on CUDA.

#166 improves general FlashAttention capability detection and may eventually touch nearby code, but this PR addresses the separate HIP boundary and does not include that implementation.

## Testing

- `tests/test_cuda_graph.py` on an RX 7900 XTX: 24 passed, 4 skipped
- Python compilation passed
- `git diff --check` passed

The real-device test used PyTorch `2.9.1+rocm7.2.1`. This verifies the backend invariant on the tested setup rather than claiming coverage for every ROCm release.
