### PR TITLE
Add an opt-in MIOpen FAST mode

### DIFF
--- a/src/yue2/cli.py
+++ b/src/yue2/cli.py
@@ -24,6 +24,13 @@ def model_paths(args):
     return model, vae
 
 
+def apply_runtime_options(args):
+    """Apply explicit process-local runtime controls before loading PyTorch models."""
+    miopen_find_mode = getattr(args, "miopen_find_mode", None)
+    if miopen_find_mode is not None:
+        os.environ["MIOPEN_FIND_MODE"] = miopen_find_mode
+
+
 def get_pipe(args):
     from .pipeline import YuE2Pipeline
     from .protocol import GenerationConfig
@@ -74,6 +81,7 @@ def doctor(args):
                         "compute_capability": [p.major, p.minor]})
     report = {"dependencies_ready": all(versions.values()), "versions": versions,
               "cuda": devices, "mps_available": torch.backends.mps.is_available(),
+              "runtime_environment": {"miopen_find_mode": os.environ.get("MIOPEN_FIND_MODE")},
               "model": model, "vae": vae, "default_cot": "full", "default_cfg": {"full": 1., "melody": 1., "off": 1.01},
               "validated": False, "note": "Environment readiness is not quality or real-24GB acceptance."}
     if args.verify_hashes:
@@ -197,6 +205,8 @@ def parser():
         q.add_argument("--backend", choices=("torch", "torch-eager", "vllm"), default="torch")
         q.add_argument("--quantization", choices=("none", "fp8"), default="none")
         q.add_argument("--offload-ar", action="store_true")
+        q.add_argument("--miopen-find-mode", choices=("FAST",),
+                       help="AMD MIOpen only: use FAST solver lookup; omitted preserves the process environment")
         q.add_argument("--offline", action="store_true")
         q.add_argument("--config")
         q.add_argument("--output")
@@ -226,6 +236,7 @@ def parser():
 def main(argv=None):
     argv = sys.argv[1:] if argv is None else argv
     args = parser().parse_args(argv)
+    apply_runtime_options(args)
     return {"doctor": doctor, "generate": generate, "batch": batch}[args.command](args)
 
 

--- a/src/yue2/pipeline.py
+++ b/src/yue2/pipeline.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 import dataclasses
 import json
+import os
 import time
 import numpy as np
 import torch
@@ -372,6 +373,7 @@ class YuE2Pipeline:
                 "vae_core_frames": self.vae_core_frames, "vae_halo_frames": 16,
                 "device": str(self.device), "memory_budget_gib": self.memory_budget_gib,
                 "offload_ar": self.offload_ar, "runtime_sha256": self.runtime_sha256,
+                "runtime_environment": {"miopen_find_mode": os.environ.get("MIOPEN_FIND_MODE")},
                 "decoder_release": json.loads((self.vae_dir / "config.json").read_text()).get("release_variant"),
                 "validation_status": "unvalidated"}
 

--- a/tests/test_cli_public.py
+++ b/tests/test_cli_public.py
@@ -1,8 +1,10 @@
 """Public installation resolves model IDs and exposes supported commands."""
 import json
+import os
 import pytest
 
 from yue2 import cli, pipeline
+from yue2.protocol import GenerationConfig, SongRequest
 
 
 @pytest.mark.parametrize("vae,repo", [
@@ -21,6 +23,51 @@ def test_cli_accepts_explicit_model_and_decoder(monkeypatch, tmp_path):
         "generate", "--model", "example/song-model", "--vae", "example/decoder",
     ])
     assert cli.model_paths(args) == ("example/song-model", "example/decoder")
+
+
+def test_miopen_find_mode_is_opt_in_and_preserves_inherited_value(monkeypatch):
+    monkeypatch.setenv("MIOPEN_FIND_MODE", "HYBRID")
+    args = cli.parser().parse_args(["generate"])
+
+    cli.apply_runtime_options(args)
+
+    assert args.miopen_find_mode is None
+    assert os.environ["MIOPEN_FIND_MODE"] == "HYBRID"
+
+
+def test_miopen_fast_is_applied_before_command_dispatch(monkeypatch):
+    monkeypatch.delenv("MIOPEN_FIND_MODE", raising=False)
+    observed = {}
+
+    def generate(args):
+        observed["mode"] = os.environ.get("MIOPEN_FIND_MODE")
+        return 0
+
+    monkeypatch.setattr(cli, "generate", generate)
+    assert cli.main(["generate", "--miopen-find-mode", "FAST"]) == 0
+    assert observed == {"mode": "FAST"}
+
+
+def test_cli_rejects_unsupported_miopen_find_modes():
+    with pytest.raises(SystemExit) as exc:
+        cli.parser().parse_args(["generate", "--miopen-find-mode", "NORMAL"])
+    assert exc.value.code == 2
+
+
+def test_effective_config_records_miopen_find_mode(monkeypatch, tmp_path):
+    monkeypatch.setenv("MIOPEN_FIND_MODE", "FAST")
+    (tmp_path / "config.json").write_text(json.dumps({"release_variant": "test"}))
+    pipe = object.__new__(pipeline.YuE2Pipeline)
+    pipe.generation_config = GenerationConfig()
+    pipe.backend, pipe.quantization = "torch", "none"
+    pipe.vae_core_frames, pipe.memory_budget_gib = 1024, 24.0
+    pipe.__dict__["device"] = "cpu"
+    pipe.offload_ar = False
+    pipe.runtime_sha256, pipe.vae_dir = "runtime", tmp_path
+
+    config = pipe.effective_config(SongRequest(style="style", lyrics="lyrics"))
+
+    assert config["runtime_environment"] == {"miopen_find_mode": "FAST"}
 
 
 @pytest.mark.parametrize("command", ["verify", "bench", "eval"])


### PR DESCRIPTION
Part of #167.

## Summary

This adds `--miopen-find-mode FAST` to the public CLI for users who want to opt into MIOpen's faster solver lookup behavior.

When the option is omitted, YuE2 leaves the existing process environment unchanged. When selected, it is applied before model initialization and recorded in `doctor` output and the saved run configuration.

## Why

MIOpen solver discovery dominated VAE decoding in one tested Windows ROCm environment. Using the same saved 58.6-second latent sequence:

| Mode | First decode | Warm decode |
|---|---:|---:|
| Existing environment | 84.48 s | 9.15 s |
| `FAST` | 7.18 s | 0.75 s |

This is a local result, not a promise for every AMD system. `FAST` remains opt-in, and this PR does not alter VAE precision, tiling, or the AR backend.

AMD documents the setting here: https://rocm.docs.amd.com/projects/MIOpen/en/latest/reference/env_variables.html

## Testing

- focused CLI/configuration tests: 12 passed
- bounded CPU-safe repository suite: 170 passed, 3 skipped, 14 deselected
- the five excluded Windows failures were reproduced unchanged on clean `main`
- live `doctor` output on the RX 7900 XTX reported the effective mode as `FAST`
- Python compilation and `git diff --check` passed
