### PR TITLE
Use utf-8 encoding for json

### DIFF
--- a/src/yue2/storage.py
+++ b/src/yue2/storage.py
@@ -25,7 +25,8 @@ def write_json(path, value):
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     temporary = path.with_name(path.name + f".{os.getpid()}.tmp")
-    temporary.write_text(json.dumps(value, indent=2, ensure_ascii=False, allow_nan=False) + "\n")
+    temporary.write_text(json.dumps(value, indent=2, ensure_ascii=False, allow_nan=False) + "\n",
+                          encoding="utf-8")
     os.replace(temporary, path)
 
 


### PR DESCRIPTION
use utf8 encoding for json, otherwise it falls back to cp1252 on windows and fails for languages like japanese