### PR TITLE
Expose optional on_progress callbacks for NAR synthesis and VAE decoding

### DIFF
--- a/src/yue2/pipeline.py
+++ b/src/yue2/pipeline.py
@@ -282,7 +282,8 @@ class YuE2Pipeline:
                         cancelled=cancelled, on_token=on_token)
         return SemanticResult(plan, [int(t) - CODEC_OFFSET for t in ids], timing, truncated)
 
-    def synthesize(self, semantic, *, cancelled=None):
+    def synthesize(self, semantic, *, cancelled=None, on_progress=None):
+        """Synthesize latents; ``on_progress(completed, total)`` reports ODE steps."""
         from .nar import synthesize
         if self.backend == "vllm":
             from .fast import close_vllm
@@ -296,11 +297,16 @@ class YuE2Pipeline:
             restore_ar(self._model)
         model = self._load_model(for_nar=True)
         with self._status("Synthesizing audio", unit="steps") as status:
-            report = (lambda completed, total: status.update(completed, total=total)) if self.progress else None
+            def report(completed, total):
+                if self.progress:
+                    status.update(completed, total=total)
+                if on_progress is not None:
+                    on_progress(completed, total)
             result = synthesize(model, semantic.plan.prefix, semantic.tokens,
                                 semantic.plan.request.seed, steps=self.generation_config.ode_steps,
                                 context=self.generation_config.context, offload_ar=self.offload_ar,
-                                cancelled=cancelled, on_progress=report)
+                                cancelled=cancelled,
+                                on_progress=report if (self.progress or on_progress is not None) else None)
             return result.detach().float().cpu().numpy()
 
     def close(self):
@@ -317,7 +323,8 @@ class YuE2Pipeline:
     def __exit__(self, *exc):
         self.close()
 
-    def decode(self, latents, *, full=False, vae=None):
+    def decode(self, latents, *, full=False, vae=None, on_progress=None):
+        """Decode latents; ``on_progress(completed, total)`` reports VAE chunks."""
         from .modeling_vae import YuE2VAE
         with self._status("Loading audio decoder"):
             if self._model is not None:
@@ -339,14 +346,21 @@ class YuE2Pipeline:
         try:
             tiles = 1 if full else (z.shape[-1] + self.vae_core_frames - 1) // self.vae_core_frames
             with self._status("Decoding audio", total=tiles, unit="chunks") as status:
-                report = (lambda completed, total: status.update(completed, total=total)) if self.progress else None
+                def report(completed, total):
+                    if self.progress:
+                        status.update(completed, total=total)
+                    if on_progress is not None:
+                        on_progress(completed, total)
                 with torch.inference_mode():
                     if full:
                         audio = model.decode(z.to(self.device)).cpu()
                         status.update(1)
+                        if on_progress is not None:
+                            on_progress(1, 1)
                     else:
                         audio = model.decode_tiled(z, core_frames=self.vae_core_frames, halo_frames=16,
-                                                   output_device="cpu", on_progress=report)
+                                                   output_device="cpu",
+                                                   on_progress=report if (self.progress or on_progress is not None) else None)
                 if not torch.isfinite(audio).all():
                     raise ValueError("VAE produced non-finite audio")
                 return audio[0].float().clamp(-1, 1).T.contiguous().numpy()
@@ -376,7 +390,7 @@ class YuE2Pipeline:
                 "validation_status": "unvalidated"}
 
     def __call__(self, style=None, lyrics=None, *, tags=None, abc_sampling=None,
-                 semantic_sampling=None, cancelled=None, on_token=None, **kwargs):
+                 semantic_sampling=None, cancelled=None, on_token=None, on_progress=None, **kwargs):
         request = self._request(style, lyrics, tags=tags, **kwargs)
         config = self.effective_config(request, abc_sampling, semantic_sampling)
         request_id = identity({"request": request.to_dict(), "config": config, "weights": self.weights})
@@ -384,12 +398,16 @@ class YuE2Pipeline:
         plan = self.plan(request=request, abc_sampling=abc_sampling, cancelled=cancelled, on_token=on_token)
         semantic = self.generate_semantic(plan, sampling=semantic_sampling, cancelled=cancelled, on_token=on_token)
         nar_start = time.perf_counter()
-        latents = self.synthesize(semantic, cancelled=cancelled)
+        latents = self.synthesize(
+            semantic, cancelled=cancelled,
+            on_progress=((lambda done, total: on_progress("nar", done, total)) if on_progress is not None else None))
         nar_seconds = time.perf_counter() - nar_start
         if cancelled is not None and cancelled():
             raise InterruptedError("Cancelled before VAE")
         vae_start = time.perf_counter()
-        audio = self.decode(latents)
+        audio = self.decode(
+            latents,
+            on_progress=((lambda done, total: on_progress("vae", done, total)) if on_progress is not None else None))
         timing = {"abc": plan.timing, "semantic": semantic.timing, "nar_seconds": nar_seconds,
                   "vae_seconds": time.perf_counter() - vae_start, "load": dict(self.load_timing),
                   "e2e_seconds": time.perf_counter() - start}

--- a/tests/test_progress_integration.py
+++ b/tests/test_progress_integration.py
@@ -167,6 +167,71 @@ def test_pipeline_passes_acoustic_callbacks_only_when_enabled(enabled, monkeypat
         assert captured.err == ''
 
 
+@pytest.mark.parametrize('enabled', [True, False])
+def test_external_on_progress_is_forwarded_independently_of_display(enabled, monkeypatch, capsys):
+    """An explicit on_progress reaches NAR/VAE even with display off, and never adds output."""
+    pipe = bare_pipe(enabled)
+    pipe.quantization, pipe.offload_ar, pipe.vae_core_frames = 'none', False, 1
+    pipe.device, pipe._model = torch.device('cpu'), None
+    expected = torch.arange(128, dtype=torch.float32).reshape(2, 64)
+    seen, external = [], []
+
+    def synthesize(model, prefix, tokens, seed, *, steps, context, offload_ar, cancelled, on_progress):
+        seen.append(on_progress is not None)
+        if on_progress is not None:
+            on_progress(1, steps)
+            on_progress(steps, steps)
+        return expected
+
+    class Decoder:
+        def to(self, device):
+            return self
+
+        def decode_tiled(self, latent, *, core_frames, halo_frames, output_device, on_progress):
+            seen.append(on_progress is not None)
+            if on_progress is not None:
+                on_progress(1, 2)
+                on_progress(2, 2)
+            return torch.zeros(1, 2, 16)
+
+    monkeypatch.setattr(nar, 'synthesize', synthesize)
+    pipe._vae = Decoder()
+    plan = pipe.plan('piano', 'original lyric', cot='off', seed=42)
+    semantic = pipeline.SemanticResult(plan, [1, 2], {}, False)
+    steps = pipe.generation_config.ode_steps
+    latent = pipe.synthesize(semantic, on_progress=lambda done, total: external.append(('nar', done, total)))
+    audio = pipe.decode(latent, on_progress=lambda done, total: external.append(('vae', done, total)))
+    assert torch.equal(torch.from_numpy(latent), expected) and audio.shape == (16, 2)
+    assert seen == [True, True]
+    assert external == [('nar', 1, steps), ('nar', steps, steps), ('vae', 1, 2), ('vae', 2, 2)]
+    captured = capsys.readouterr()
+    assert captured.out == ''
+    if enabled:
+        assert 'Completed Synthesizing audio: 32/32 steps' in captured.err
+        assert 'Completed Decoding audio: 2/2 chunks' in captured.err
+    else:
+        assert captured.err == ''
+
+
+def test_full_decode_reports_its_single_chunk_to_external_on_progress(monkeypatch, capsys):
+    pipe = bare_pipe(False)
+    pipe.quantization, pipe.offload_ar, pipe.vae_core_frames = 'none', False, 1
+    pipe.device, pipe._model = torch.device('cpu'), None
+    external = []
+
+    class Decoder:
+        def to(self, device):
+            return self
+
+        def decode(self, latent):
+            return torch.zeros(1, 2, 16)
+
+    pipe._vae = Decoder()
+    audio = pipe.decode(torch.zeros(2, 64), full=True, on_progress=lambda done, total: external.append((done, total)))
+    assert audio.shape == (16, 2) and external == [(1, 1)]
+    assert capsys.readouterr() == ('', '')
+
+
 @pytest.mark.parametrize('command', ['generate', 'batch'])
 @pytest.mark.parametrize('quiet_flag', [None, '--quiet', '--no-progress'])
 def test_cli_quiet_propagates_and_does_not_pollute_result_stdout(command, quiet_flag, monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
## Motivation

External callers (web UIs, notebooks, job runners) have no way to observe ODE-step and VAE-chunk progress other than parsing the stderr reporter, which is display-only and silent when `progress=False`. The AR stages already offer `on_token`; this adds the equivalent for the acoustic stages.

## Change

- `YuE2Pipeline.synthesize(..., on_progress=None)` and `decode(..., on_progress=None)` accept an optional `on_progress(completed, total)` callback (ODE steps / VAE chunks).
- `YuE2Pipeline.__call__(..., on_progress=None)` accepts `on_progress(stage, completed, total)` and routes the two stages with the labels `"nar"` and `"vae"`.

The change is additive:

- With the argument omitted, behaviour and output are identical to today.
- The existing rule that the acoustic stages receive a callback only when display is enabled still holds — `test_pipeline_passes_acoustic_callbacks_only_when_enabled` passes unchanged.
- When an external callback is supplied it is forwarded regardless of the display setting and produces no stream output.

## Tests

Two CPU contract tests in `tests/test_progress_integration.py`, mirroring the existing ones: forwarding for the tiled decode path with display on and off, and the single-chunk report for `full=True`.

`python -m pytest -q` → 175 passed, 11 skipped (172 + 2 new + 1 parametrized).

## Context

I'm using this from a Gradio front end for YuE2 (bf16 on Apple MPS with torch ≥ 2.11; the pinned 2.10.0 hits pytorch/pytorch#174861 in the single-query SDPA path once the KV cache passes 1024 tokens — happy to open a separate issue/PR about the pin if useful).
